### PR TITLE
Dodanie automatycznego regenerowania pliku README.md

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -1,0 +1,44 @@
+name: Update README.md
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "pl-*.md"
+      - "!pl-template.md"
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    name: Update README.md
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Prepare directories
+        uses: actions/checkout@v2
+        with:
+          repository: pastaandpizza/readmegen
+          path: ./.tools
+      - name: Build readmegen
+        working-directory: ./.tools
+        run: go build .
+      - name: Move readmegen
+        run: mv .tools/readmegen .
+      - name: Run readmegen
+        run: ./readmegen -template .tools/templates/readme.gotmpl $(ls pl-*.md | grep -v "pl-template.md")
+        continue-on-error: false
+      - name: Push changes
+        uses: test-room-7/action-update-file@v1
+        with:
+          file-path: README.md
+          commit-msg: "readme: rebuild contents"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .vim
 .ide
 .typora
+
+.tools
+readmegen

--- a/pl-crepes.md
+++ b/pl-crepes.md
@@ -1,3 +1,8 @@
+---
+title: "Crepes"
+categories: ["Naleśniki i racuchy"]
+---
+
 # Crepes
 
 ## Składniki

--- a/pl-guanciale.md
+++ b/pl-guanciale.md
@@ -1,3 +1,8 @@
+---
+title: "Guanciale - podgardle dojrzewające"
+categories: ["Wędliny"]
+---
+
 # Guanciale
 
 ## Składniki

--- a/pl-jogurt-z-orzechami-wloskimi-i-miodem.md
+++ b/pl-jogurt-z-orzechami-wloskimi-i-miodem.md
@@ -1,3 +1,8 @@
+---
+title: "Jogurt z orzechami włoskimi i miodem"
+categories: ["Desery"]
+---
+
 # Jogurt z orzechami włoskimi i miodem
 
 ## Składniki

--- a/pl-kotleciki-ziemniaczane-z-jajek.md
+++ b/pl-kotleciki-ziemniaczane-z-jajek.md
@@ -1,3 +1,8 @@
+---
+title: "Kotleciki z jajek i sosem beszamel"
+categories: ["Kotlety"]
+---
+
 # Kotleciki z jajek i sosem beszamel
 
 ## Składniki

--- a/pl-pizza-margherita-wersja-do-pieca-domowego.md
+++ b/pl-pizza-margherita-wersja-do-pieca-domowego.md
@@ -1,3 +1,8 @@
+---
+title: "Pizza Margherita - wersja do pieca domowego"
+categories: ["Pizza"]
+---
+
 # Pizza Margherita - wersja do pieca domowego
 
 ## Składniki

--- a/pl-template.md
+++ b/pl-template.md
@@ -1,3 +1,8 @@
+---
+title: "Nazwa przepisu/potrawy"
+categories: ["Przykładowa kategoria"]
+---
+
 # Nazwa przepisy/potrawy
 
 _Komentarze do szablonu są zapisane kursywą_


### PR DESCRIPTION
## Opis zmian

Dodane elementy pozwolą na automatyczne generowanie pliku `README.md` na podstawie metadanych przepisów. Za każdym razem wystarczy więc dodać przepis do repozytorium, nie przejmując się koniecznością wprowadzania zmian w pliku `README.md`. Rozwiązanie bazuje na przygotowanym specjalnie do tego celu narzędziu `readmegen`, zawartym w repozytorium [`pastaandpizza/readmegen`](https://github.com/pastaandpizza/readmegen).

## Lista zmian

- ca82a8b: dodanie katalogu `.tools` i pliku `readmegen` do pliku `.gitignore`
- 8acf0cc: dodanie przykładu metadanych do szablonu przepisu
- d89edb3: dodanie metadanych do istniejących przepisów
- 276b424: dodanie automatyzacji regenerowania pliku `README.md` przy aktualizacji przepisów